### PR TITLE
R tutorial follow up

### DIFF
--- a/R/mlflow/R/model.R
+++ b/R/mlflow/R/model.R
@@ -11,7 +11,7 @@
 #' @export
 mlflow_save_model <- function(fn, path = "model") {
 
-  if (!"crate" %in% class(fn)) {
+  if (!inherits(fn, "crate")) {
     stop("Serving function must be crated using mlflow::crate().")
   }
 
@@ -95,7 +95,7 @@ mlflow_rfunc_predict <- function(
 
   model <- mlflow_load_model(model_dir)
 
-  if (!"crate" %in% class(model)) {
+  if (!inherits(model, "crate")) {
     stop("MLflow rfunc model expected to be crated using mlflow::crate().")
   }
 

--- a/R/mlflow/R/run.R
+++ b/R/mlflow/R/run.R
@@ -36,9 +36,10 @@ mlflow_run <- function(uri = "", entry_point = NULL, version = NULL, param_list 
     mlflow_cli_param("--cluster_spec", cluster_spec) %>%
     mlflow_cli_param("--git-username", git_username) %>%
     mlflow_cli_param("--git-password", git_password) %>%
-    mlflow_cli_param("--no-conda", if (no_conda) "") %>%
     mlflow_cli_param("--storage-dir", storage_dir) %>%
     c(param_list)
+
+  args <- if (!no_conda) args else c(args, "--no-conda")
 
   do.call(mlflow_cli, c("run", args))
 

--- a/R/mlflow/R/run.R
+++ b/R/mlflow/R/run.R
@@ -17,7 +17,7 @@
 #' @param storage_dir Only valid when `mode` is local. MLflow downloads artifacts from distributed URIs passed to
 #'  parameters of type 'path' to subdirectories of storage_dir.
 #' @export
-mlflow_run <- function(uri = "", entry_point = NULL, version = NULL, param_list = NULL,
+mlflow_run <- function(uri = ".", entry_point = NULL, version = NULL, param_list = NULL,
                        experiment_id = NULL, mode = NULL, cluster_spec = NULL,
                        git_username = NULL, git_password = NULL, no_conda = FALSE,
                        storage_dir = NULL) {

--- a/R/mlflow/R/tracking-rest.R
+++ b/R/mlflow/R/tracking-rest.R
@@ -148,7 +148,7 @@ mlflow_get_run <- function(run_uuid) {
 #' @param timestamp Unix timestamp in milliseconds at the time metric was logged.
 #' @export
 mlflow_log_metric <- function(key, value, timestamp = NULL, run_uuid = NULL) {
-  if (!class(value)[[1]] %in% c("character", "numeric", "integer")) {
+  if (!rlang::inherits_any(value, c("character", "numeric", "integer"))) {
     stop("Metric ", key, " must be a character or numeric but ", class(value), " found.")
   }
 

--- a/R/mlflow/R/tracking.R
+++ b/R/mlflow/R/tracking.R
@@ -180,11 +180,12 @@ mlflow_ensure_run <- function(run_uuid) {
 #' but stores model as an artifact within the active run.
 #'
 #' @param fn The serving function that will perform a prediction.
-#' @param path Destination path where this MLflow compatible model
+#' @param artifact_path Destination path where this MLflow compatible model
 #'   will be saved.
 #'
 #' @export
-mlflow_log_model <- function(fn, path = "model") {
-  mlflow_save_model(fn, path = path)
-  mlflow_log_artifact(path)
+mlflow_log_model <- function(fn, artifact_path = NULL) {
+  temp_path <- fs::path_temp(artifact_path)
+  mlflow_save_model(fn, path = temp_path)
+  mlflow_log_artifact(temp_path, artifact_path)
 }

--- a/R/mlflow/man/mlflow_log_model.Rd
+++ b/R/mlflow/man/mlflow_log_model.Rd
@@ -4,12 +4,12 @@
 \alias{mlflow_log_model}
 \title{Log Model}
 \usage{
-mlflow_log_model(fn, path = "model")
+mlflow_log_model(fn, artifact_path = NULL)
 }
 \arguments{
 \item{fn}{The serving function that will perform a prediction.}
 
-\item{path}{Destination path where this MLflow compatible model
+\item{artifact_path}{Destination path where this MLflow compatible model
 will be saved.}
 }
 \description{

--- a/R/mlflow/man/mlflow_run.Rd
+++ b/R/mlflow/man/mlflow_run.Rd
@@ -4,7 +4,7 @@
 \alias{mlflow_run}
 \title{Run in MLflow}
 \usage{
-mlflow_run(uri = "", entry_point = NULL, version = NULL,
+mlflow_run(uri = ".", entry_point = NULL, version = NULL,
   param_list = NULL, experiment_id = NULL, mode = NULL,
   cluster_spec = NULL, git_username = NULL, git_password = NULL,
   no_conda = FALSE, storage_dir = NULL)

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -157,8 +157,8 @@ Training the Model
         alpha <- mlflow_param("alpha", 0.5, "numeric")
         lambda <- mlflow_param("lambda", 0.5, "numeric")
 
-        mlflow_start_run({
-          model <- glmnet(train_x, train_y, alpha=alpha, lambda=lambda, family="gaussian")
+        with(mlflow_start_run(), {
+          model <- glmnet(train_x, train_y, alpha = alpha, lambda = lambda, family = "gaussian")
           predictor <- crate(~ stats::predict(model, .x), model)
           predicted <- predictor(test_x)
 

--- a/example/tutorial/train.R
+++ b/example/tutorial/train.R
@@ -25,7 +25,7 @@ alpha <- mlflow_param("alpha", 0.5, "numeric")
 lambda <- mlflow_param("lambda", 0.5, "numeric")
 
 with(mlflow_start_run(), {
-    model <- glmnet(train_x, train_y, alpha=alpha, lambda=lambda, family="gaussian")
+    model <- glmnet(train_x, train_y, alpha = alpha, lambda = lambda, family= "gaussian")
     predictor <- crate(~ stats::predict(model, .x), model)
     predicted <- predictor(test_x)
 

--- a/example/tutorial/train.R
+++ b/example/tutorial/train.R
@@ -24,7 +24,7 @@ test_y <- test[, "quality"]
 alpha <- mlflow_param("alpha", 0.5, "numeric")
 lambda <- mlflow_param("lambda", 0.5, "numeric")
 
-mlflow_start_run({
+with(mlflow_start_run(), {
     model <- glmnet(train_x, train_y, alpha=alpha, lambda=lambda, family="gaussian")
     predictor <- crate(~ stats::predict(model, .x), model)
     predicted <- predictor(test_x)

--- a/example/tutorial/train.Rmd
+++ b/example/tutorial/train.Rmd
@@ -41,8 +41,8 @@ lambda <- mlflow_param("lambda", 0.5, "numeric")
 ```
 
 ```{r}
-mlflow_start_run({
-    model <- glmnet(train_x, train_y, alpha=alpha, lambda=lambda, family="gaussian")
+with(mlflow_start_run(), {
+    model <- glmnet(train_x, train_y, alpha = alpha, lambda = lambda, family = "gaussian")
     predictor <- crate(~ stats::predict(model, .x), model)
     predicted <- predictor(test_x)
 


### PR DESCRIPTION
- The correct syntax is `with(mlflow_start_run(), {...})` and not `mlflow_start_run({...})`.
- Fixed the `no_conda` parameter for `mlflow_run()`. Running examples requires `no_conda = TRUE` since by default mlflow grabs the latest release of mlflow and there seems to be a bug (related to listing experiments) that was recently fixed.
- `mlflow_log_model()` shouldn't persist the saved model locally.
- Minor cosmetic changes.