### PR TITLE
Support run_id in rfunc predict/serve and other changes

### DIFF
--- a/R/mlflow/R/artifact.R
+++ b/R/mlflow/R/artifact.R
@@ -1,8 +1,3 @@
-mlflow_active_artifact_uri <- function() {
-  run_info <- mlflow_active_run()
-  run_info$run_info$artifact_uri
-}
-
 mlflow_artifact_type <- function(artifact_uri) {
   artifact_type <- NULL
   if (dir.exists(artifact_uri)) {
@@ -70,9 +65,9 @@ mlflow_artifact_type <- function(artifact_uri) {
 #' by Amazon IAM.
 #'
 #' @export
-mlflow_log_artifact <- function(path, artifact_path = NULL) {
-  mlflow_get_or_create_active_connection()
-  artifact_uri <- mlflow_active_artifact_uri()
+mlflow_log_artifact <- function(path, artifact_path = NULL, run_uuid = NULL) {
+  run_uuid <- mlflow_ensure_run_id(run_uuid)
+  artifact_uri <- mlflow_get_run(run_uuid)$info$artifact_uri
   artifact_type <- mlflow_artifact_type(artifact_uri)
 
   artifact_uri <- ifelse(

--- a/R/mlflow/R/artifact.R
+++ b/R/mlflow/R/artifact.R
@@ -99,7 +99,7 @@ mlflow_log_artifact_impl.local_artifact <- function(artifact_uri, path) {
     dir.create(artifact_uri, recursive = TRUE)
   }
 
-  file.copy(path, artifact_uri)
+  file.copy(path, artifact_uri, overwrite = TRUE)
   invisible(NULL)
 }
 

--- a/R/mlflow/R/artifact.R
+++ b/R/mlflow/R/artifact.R
@@ -32,6 +32,7 @@ mlflow_artifact_type <- function(artifact_uri) {
 #'
 #' @param path The file or directory to log as an artifact.
 #' @param artifact_path Destination path within the run’s artifact URI.
+#' @param run_uuid The run associated with this artifact.
 #'
 #' @details
 #'
@@ -65,7 +66,7 @@ mlflow_artifact_type <- function(artifact_uri) {
 #' by Amazon IAM.
 #'
 #' @export
-mlflow_log_artifact <- function(path, artifact_path = NULL, run_uuid = NULL) {
+mlflow_log_artifact <- function(path, artifact_path, run_uuid = NULL) {
   run_uuid <- mlflow_ensure_run_id(run_uuid)
   artifact_uri <- mlflow_get_run(run_uuid)$info$artifact_uri
   artifact_type <- mlflow_artifact_type(artifact_uri)

--- a/R/mlflow/R/artifact.R
+++ b/R/mlflow/R/artifact.R
@@ -71,7 +71,7 @@ mlflow_artifact_type <- function(artifact_uri) {
 #'
 #' @export
 mlflow_log_artifact <- function(path, artifact_path = NULL) {
-
+  mlflow_get_or_create_active_connection()
   artifact_uri <- mlflow_active_artifact_uri()
   artifact_type <- mlflow_artifact_type(artifact_uri)
 

--- a/R/mlflow/R/model.R
+++ b/R/mlflow/R/model.R
@@ -64,7 +64,7 @@ mlflow_rfunc_predict_impl <- function(model, data) {
 #' Predict using an RFunc MLflow Model from a file or data frame.
 #'
 #' @param model_path The path to the MLflow model, as a string.
-#' @param run_id Run ID of run to grab the model from.
+#' @param run_uuid Run ID of run to grab the model from.
 #' @param input_path Path to 'JSON' or 'CSV' file to be used for prediction.
 #' @param output_path 'JSON' or 'CSV' file where the prediction will be written to.
 #' @param data Data frame to be scored. This can be utilized for testing purposes and can only
@@ -90,7 +90,7 @@ mlflow_rfunc_predict_impl <- function(model, data) {
 #' @export
 mlflow_rfunc_predict <- function(
   model_path,
-  run_id = NULL,
+  run_uuid = NULL,
   input_path = NULL,
   output_path = NULL,
   data = NULL,
@@ -98,7 +98,7 @@ mlflow_rfunc_predict <- function(
 ) {
   mlflow_restore_or_warning(restore)
 
-  model_path <- resolve_model_path(model_path, run_id)
+  model_path <- resolve_model_path(model_path, run_uuid)
 
   if (!xor(is.null(input_path), is.null(data)))
     stop("One and only one of `input_path` or `data` must be specified.")
@@ -132,12 +132,12 @@ mlflow_rfunc_predict <- function(
   }
 }
 
-resolve_model_path <- function(model_path, run_id) {
-  if (!is.null(run_id)) {
+resolve_model_path <- function(model_path, run_uuid) {
+  if (!is.null(run_uuid)) {
     mlflow_get_or_create_active_connection()
     result <- withr::with_envvar(
       list(MLFLOW_TRACKING_URI = mlflow_tracking_uri()),
-      mlflow_cli("artifacts", "download", "--run-id", run_id, "-a", model_path, echo = FALSE)
+      mlflow_cli("artifacts", "download", "--run-id", run_uuid, "-a", model_path, echo = FALSE)
     )
       gsub("\n", "", result$stdout)
   } else {

--- a/R/mlflow/R/model.R
+++ b/R/mlflow/R/model.R
@@ -25,16 +25,19 @@ mlflow_save_model <- function(fn, path = "model") {
     file.path(path, "r_model.bin")
   )
 
-  write_yaml(
-    list(
-      time_created = Sys.time(),
-      flavors = list(
-        r_function = list(
-          version = "0.1.0",
-          model = "r_model.bin"
-        )
+  ml_model_content <- list(
+    time_created = Sys.time(),
+    run_id = mlflow_active_run()$run_info$run_uuid,
+    flavors = list(
+      r_function = list(
+        version = "0.1.0",
+        model = "r_model.bin"
       )
-    ),
+    )
+  )
+
+  write_yaml(
+    purrr::compact(ml_model_content),
     file.path(path, "MLmodel")
   )
 }

--- a/R/mlflow/R/model.R
+++ b/R/mlflow/R/model.R
@@ -39,13 +39,13 @@ mlflow_save_model <- function(fn, path = "model") {
   )
 }
 
-mlflow_load_model <- function(model_dir) {
-  spec <- yaml::read_yaml(fs::path(model_dir, "MLmodel"))
+mlflow_load_model <- function(model_path) {
+  spec <- yaml::read_yaml(fs::path(model_path, "MLmodel"))
 
   if (!"r_function" %in% names(spec$flavors))
     stop("Model must define r_function to be used from R.")
 
-  unserialize(readRDS(fs::path(model_dir, spec$flavors$r_function$model)))
+  unserialize(readRDS(fs::path(model_path, spec$flavors$r_function$model)))
 }
 
 mlflow_rfunc_predict_impl <- function(model, data) {
@@ -63,7 +63,7 @@ mlflow_rfunc_predict_impl <- function(model, data) {
 #'
 #' Predict using an RFunc MLflow Model from a file or data frame.
 #'
-#' @param model_dir The path to the MLflow model, as a string.
+#' @param model_path The path to the MLflow model, as a string.
 #' @param data Data frame, 'JSON' or 'CSV' file to be used for prediction.
 #' @param output_file 'JSON' or 'CSV' file where the prediction will be written to.
 #' @param restore Should \code{mlflow_restore_snapshot()} be called before serving?
@@ -86,7 +86,7 @@ mlflow_rfunc_predict_impl <- function(model, data) {
 #' @importFrom utils write.csv
 #' @export
 mlflow_rfunc_predict <- function(
-  model_dir,
+  model_path,
   data,
   output_file = NULL,
   restore = FALSE
@@ -101,7 +101,7 @@ mlflow_rfunc_predict <- function(
     )
   }
 
-  model <- mlflow_load_model(model_dir)
+  model <- mlflow_load_model(model_path)
 
   prediction <- mlflow_rfunc_predict_impl(model, data)
 

--- a/R/mlflow/R/serve.R
+++ b/R/mlflow/R/serve.R
@@ -5,6 +5,7 @@
 #' Serve an RFunc MLflow Model as a local web api under \url{http://localhost:8090}.
 #'
 #' @param model_path The path to the MLflow model, as a string.
+#' @param run_id ID of run to grab the model from.
 #' @param host Address to use to serve model, as a string.
 #' @param port Port to use to serve model, as numeric.
 #' @param daemonized Makes 'httpuv' server daemonized so R interactive sessions
@@ -33,6 +34,7 @@
 #' @export
 mlflow_rfunc_serve <- function(
   model_path,
+  run_id = NULL,
   host = "127.0.0.1",
   port = 8090,
   daemonized = FALSE,
@@ -40,6 +42,8 @@ mlflow_rfunc_serve <- function(
   restore = FALSE
 ) {
   mlflow_restore_or_warning(restore)
+
+  model_path <- resolve_model_path(model_path, run_id)
 
   httpuv_start <- if (daemonized) httpuv::startDaemonizedServer else httpuv::runServer
   serve_run(model_path, host, port, httpuv_start, browse && interactive())

--- a/R/mlflow/R/serve.R
+++ b/R/mlflow/R/serve.R
@@ -4,7 +4,7 @@
 #'
 #' Serve an RFunc MLflow Model as a local web api under \url{http://localhost:8090}.
 #'
-#' @param model_dir The path to the MLflow model, as a string.
+#' @param model_path The path to the MLflow model, as a string.
 #' @param host Address to use to serve model, as a string.
 #' @param port Port to use to serve model, as numeric.
 #' @param daemonized Makes 'httpuv' server daemonized so R interactive sessions
@@ -32,7 +32,7 @@
 #' @import swagger
 #' @export
 mlflow_rfunc_serve <- function(
-  model_dir,
+  model_path,
   host = "127.0.0.1",
   port = 8090,
   daemonized = FALSE,
@@ -42,7 +42,7 @@ mlflow_rfunc_serve <- function(
   mlflow_restore_or_warning(restore)
 
   httpuv_start <- if (daemonized) httpuv::startDaemonizedServer else httpuv::runServer
-  serve_run(model_dir, host, port, httpuv_start, browse && interactive())
+  serve_run(model_path, host, port, httpuv_start, browse && interactive())
 }
 
 serve_content_type <- function(file_path) {
@@ -181,8 +181,8 @@ message_serve_start <- function(host, port, model) {
 }
 
 #' @importFrom utils browseURL
-serve_run <- function(model_dir, host, port, start, browse) {
-  model <- mlflow_load_model(model_dir)
+serve_run <- function(model_path, host, port, start, browse) {
+  model <- mlflow_load_model(model_path)
 
   message_serve_start(host, port, model)
 

--- a/R/mlflow/R/serve.R
+++ b/R/mlflow/R/serve.R
@@ -5,7 +5,7 @@
 #' Serve an RFunc MLflow Model as a local web api under \url{http://localhost:8090}.
 #'
 #' @param model_path The path to the MLflow model, as a string.
-#' @param run_id ID of run to grab the model from.
+#' @param run_uuid ID of run to grab the model from.
 #' @param host Address to use to serve model, as a string.
 #' @param port Port to use to serve model, as numeric.
 #' @param daemonized Makes 'httpuv' server daemonized so R interactive sessions
@@ -34,7 +34,7 @@
 #' @export
 mlflow_rfunc_serve <- function(
   model_path,
-  run_id = NULL,
+  run_uuid = NULL,
   host = "127.0.0.1",
   port = 8090,
   daemonized = FALSE,
@@ -43,7 +43,7 @@ mlflow_rfunc_serve <- function(
 ) {
   mlflow_restore_or_warning(restore)
 
-  model_path <- resolve_model_path(model_path, run_id)
+  model_path <- resolve_model_path(model_path, run_uuid)
 
   httpuv_start <- if (daemonized) httpuv::startDaemonizedServer else httpuv::runServer
   serve_run(model_path, host, port, httpuv_start, browse && interactive())

--- a/R/mlflow/R/tracking-rest.R
+++ b/R/mlflow/R/tracking-rest.R
@@ -152,7 +152,7 @@ mlflow_log_metric <- function(key, value, timestamp = NULL, run_uuid = NULL) {
     stop("Metric ", key, " must be a character or numeric but ", class(value), " found.")
   }
 
-  run_uuid <- mlflow_ensure_run(run_uuid)
+  run_uuid <- mlflow_ensure_run_id(run_uuid)
   timestamp <- timestamp %||% current_time()
   response <- mlflow_rest("runs", "log-metric", verb = "POST", data = list(
     run_uuid = run_uuid,
@@ -176,7 +176,7 @@ mlflow_log_metric <- function(key, value, timestamp = NULL, run_uuid = NULL) {
 #' @param value String value of the parameter.
 #' @export
 mlflow_log_param <- function(key, value, run_uuid = NULL) {
-  run_uuid <- mlflow_ensure_run(run_uuid)
+  run_uuid <- mlflow_ensure_run_id(run_uuid)
   response <- mlflow_rest("runs", "log-parameter", verb = "POST", data = list(
     run_uuid = run_uuid,
     key = key,

--- a/R/mlflow/R/tracking.R
+++ b/R/mlflow/R/tracking.R
@@ -166,11 +166,18 @@ with.mlflow_active_run <- function(data, expr, ...) {
   invisible(NULL)
 }
 
-mlflow_ensure_run <- function(run_uuid) {
+mlflow_ensure_run_id <- function(run_uuid) {
   if (is.null(run_uuid)) {
-    mlflow_active_run()$run_info$run_uuid %||% mlflow_start_run()$run_info$run_uuid
+    run <- mlflow_active_run() %||% mlflow_start_run()
+    run$run_info$run_uuid
   } else {
-    mlflow_start_run(run_uuid)$run_info$run_uuid
+    mlflow_get_or_create_active_connection()
+    tryCatch(mlflow_get_run(run_uuid)$info$run_uuid, error = function(e) {
+      stop(
+        "Run \"", run_uuid, "\" cannot be found in current tracking server at ",
+        mlflow_tracking_uri(), "."
+      )
+    })
   }
 }
 

--- a/R/mlflow/R/tracking.R
+++ b/R/mlflow/R/tracking.R
@@ -189,10 +189,11 @@ mlflow_ensure_run_id <- function(run_uuid) {
 #' @param fn The serving function that will perform a prediction.
 #' @param artifact_path Destination path where this MLflow compatible model
 #'   will be saved.
+#' @param run_uuid The run associated with the model to be logged.
 #'
 #' @export
-mlflow_log_model <- function(fn, artifact_path = NULL) {
+mlflow_log_model <- function(fn, artifact_path = NULL, run_uuid = NULL) {
   temp_path <- fs::path_temp(artifact_path)
   mlflow_save_model(fn, path = temp_path)
-  mlflow_log_artifact(temp_path, artifact_path)
+  mlflow_log_artifact(path = temp_path, artifact_path = artifact_path, run_uuid = run_uuid)
 }

--- a/R/mlflow/R/tracking.R
+++ b/R/mlflow/R/tracking.R
@@ -192,7 +192,7 @@ mlflow_ensure_run_id <- function(run_uuid) {
 #' @param run_uuid The run associated with the model to be logged.
 #'
 #' @export
-mlflow_log_model <- function(fn, artifact_path = NULL, run_uuid = NULL) {
+mlflow_log_model <- function(fn, artifact_path, run_uuid = NULL) {
   temp_path <- fs::path_temp(artifact_path)
   mlflow_save_model(fn, path = temp_path)
   mlflow_log_artifact(path = temp_path, artifact_path = artifact_path, run_uuid = run_uuid)

--- a/R/mlflow/man/mlflow_log_artifact.Rd
+++ b/R/mlflow/man/mlflow_log_artifact.Rd
@@ -4,12 +4,14 @@
 \alias{mlflow_log_artifact}
 \title{Log Artifact}
 \usage{
-mlflow_log_artifact(path, artifact_path = NULL, run_uuid = NULL)
+mlflow_log_artifact(path, artifact_path, run_uuid = NULL)
 }
 \arguments{
 \item{path}{The file or directory to log as an artifact.}
 
 \item{artifact_path}{Destination path within the run’s artifact URI.}
+
+\item{run_uuid}{The run associated with this artifact.}
 }
 \description{
 Logs an specific file or directory as an artifact.

--- a/R/mlflow/man/mlflow_log_artifact.Rd
+++ b/R/mlflow/man/mlflow_log_artifact.Rd
@@ -4,7 +4,7 @@
 \alias{mlflow_log_artifact}
 \title{Log Artifact}
 \usage{
-mlflow_log_artifact(path, artifact_path = NULL)
+mlflow_log_artifact(path, artifact_path = NULL, run_uuid = NULL)
 }
 \arguments{
 \item{path}{The file or directory to log as an artifact.}

--- a/R/mlflow/man/mlflow_log_model.Rd
+++ b/R/mlflow/man/mlflow_log_model.Rd
@@ -4,13 +4,15 @@
 \alias{mlflow_log_model}
 \title{Log Model}
 \usage{
-mlflow_log_model(fn, artifact_path = NULL)
+mlflow_log_model(fn, artifact_path = NULL, run_uuid = NULL)
 }
 \arguments{
 \item{fn}{The serving function that will perform a prediction.}
 
 \item{artifact_path}{Destination path where this MLflow compatible model
 will be saved.}
+
+\item{run_uuid}{The run associated with the model to be logged.}
 }
 \description{
 Logs a model in the given run. Similar to `mlflow_save_model()`

--- a/R/mlflow/man/mlflow_log_model.Rd
+++ b/R/mlflow/man/mlflow_log_model.Rd
@@ -4,7 +4,7 @@
 \alias{mlflow_log_model}
 \title{Log Model}
 \usage{
-mlflow_log_model(fn, artifact_path = NULL, run_uuid = NULL)
+mlflow_log_model(fn, artifact_path, run_uuid = NULL)
 }
 \arguments{
 \item{fn}{The serving function that will perform a prediction.}

--- a/R/mlflow/man/mlflow_rfunc_predict.Rd
+++ b/R/mlflow/man/mlflow_rfunc_predict.Rd
@@ -4,13 +4,13 @@
 \alias{mlflow_rfunc_predict}
 \title{Predict using RFunc MLflow Model}
 \usage{
-mlflow_rfunc_predict(model_path, run_id = NULL, input_path = NULL,
+mlflow_rfunc_predict(model_path, run_uuid = NULL, input_path = NULL,
   output_path = NULL, data = NULL, restore = FALSE)
 }
 \arguments{
 \item{model_path}{The path to the MLflow model, as a string.}
 
-\item{run_id}{Run ID of run to grab the model from.}
+\item{run_uuid}{Run ID of run to grab the model from.}
 
 \item{input_path}{Path to 'JSON' or 'CSV' file to be used for prediction.}
 

--- a/R/mlflow/man/mlflow_rfunc_predict.Rd
+++ b/R/mlflow/man/mlflow_rfunc_predict.Rd
@@ -4,11 +4,11 @@
 \alias{mlflow_rfunc_predict}
 \title{Predict using RFunc MLflow Model}
 \usage{
-mlflow_rfunc_predict(model_dir, data, output_file = NULL,
+mlflow_rfunc_predict(model_path, data, output_file = NULL,
   restore = FALSE)
 }
 \arguments{
-\item{model_dir}{The path to the MLflow model, as a string.}
+\item{model_path}{The path to the MLflow model, as a string.}
 
 \item{data}{Data frame, 'JSON' or 'CSV' file to be used for prediction.}
 

--- a/R/mlflow/man/mlflow_rfunc_predict.Rd
+++ b/R/mlflow/man/mlflow_rfunc_predict.Rd
@@ -4,15 +4,20 @@
 \alias{mlflow_rfunc_predict}
 \title{Predict using RFunc MLflow Model}
 \usage{
-mlflow_rfunc_predict(model_path, data, output_file = NULL,
-  restore = FALSE)
+mlflow_rfunc_predict(model_path, run_id = NULL, input_path = NULL,
+  output_path = NULL, data = NULL, restore = FALSE)
 }
 \arguments{
 \item{model_path}{The path to the MLflow model, as a string.}
 
-\item{data}{Data frame, 'JSON' or 'CSV' file to be used for prediction.}
+\item{run_id}{Run ID of run to grab the model from.}
 
-\item{output_file}{'JSON' or 'CSV' file where the prediction will be written to.}
+\item{input_path}{Path to 'JSON' or 'CSV' file to be used for prediction.}
+
+\item{output_path}{'JSON' or 'CSV' file where the prediction will be written to.}
+
+\item{data}{Data frame to be scored. This can be utilized for testing purposes and can only
+be specified when `input_path` is not specified.}
 
 \item{restore}{Should \code{mlflow_restore_snapshot()} be called before serving?}
 }

--- a/R/mlflow/man/mlflow_rfunc_serve.Rd
+++ b/R/mlflow/man/mlflow_rfunc_serve.Rd
@@ -4,11 +4,11 @@
 \alias{mlflow_rfunc_serve}
 \title{Serve an RFunc MLflow Model}
 \usage{
-mlflow_rfunc_serve(model_dir, host = "127.0.0.1", port = 8090,
+mlflow_rfunc_serve(model_path, host = "127.0.0.1", port = 8090,
   daemonized = FALSE, browse = !daemonized, restore = FALSE)
 }
 \arguments{
-\item{model_dir}{The path to the MLflow model, as a string.}
+\item{model_path}{The path to the MLflow model, as a string.}
 
 \item{host}{Address to use to serve model, as a string.}
 

--- a/R/mlflow/man/mlflow_rfunc_serve.Rd
+++ b/R/mlflow/man/mlflow_rfunc_serve.Rd
@@ -4,11 +4,14 @@
 \alias{mlflow_rfunc_serve}
 \title{Serve an RFunc MLflow Model}
 \usage{
-mlflow_rfunc_serve(model_path, host = "127.0.0.1", port = 8090,
-  daemonized = FALSE, browse = !daemonized, restore = FALSE)
+mlflow_rfunc_serve(model_path, run_id = NULL, host = "127.0.0.1",
+  port = 8090, daemonized = FALSE, browse = !daemonized,
+  restore = FALSE)
 }
 \arguments{
 \item{model_path}{The path to the MLflow model, as a string.}
+
+\item{run_id}{ID of run to grab the model from.}
 
 \item{host}{Address to use to serve model, as a string.}
 

--- a/R/mlflow/man/mlflow_rfunc_serve.Rd
+++ b/R/mlflow/man/mlflow_rfunc_serve.Rd
@@ -4,14 +4,14 @@
 \alias{mlflow_rfunc_serve}
 \title{Serve an RFunc MLflow Model}
 \usage{
-mlflow_rfunc_serve(model_path, run_id = NULL, host = "127.0.0.1",
+mlflow_rfunc_serve(model_path, run_uuid = NULL, host = "127.0.0.1",
   port = 8090, daemonized = FALSE, browse = !daemonized,
   restore = FALSE)
 }
 \arguments{
 \item{model_path}{The path to the MLflow model, as a string.}
 
-\item{run_id}{ID of run to grab the model from.}
+\item{run_uuid}{ID of run to grab the model from.}
 
 \item{host}{Address to use to serve model, as a string.}
 

--- a/R/mlflow/tests/testthat/test_model.R
+++ b/R/mlflow/tests/testthat/test_model.R
@@ -6,7 +6,8 @@ test_that("mlflow can save model function", {
   model <- lm(Sepal.Width ~ Sepal.Length, iris)
 
   fn <- crate(~ stats::predict(model, .x), model)
-  mlflow_save_model(fn)
+
+  mlflow_log_model(fn, "model")
 
   expect_true(dir.exists("model"))
 

--- a/R/mlflow/tests/testthat/test_model.R
+++ b/R/mlflow/tests/testthat/test_model.R
@@ -10,7 +10,7 @@ test_that("mlflow can save model function", {
 
   expect_true(dir.exists("model"))
 
-  prediction <- mlflow_rfunc_predict("model", iris)
+  prediction <- mlflow_rfunc_predict("model", data = iris)
   expect_true(!is.null(prediction))
 
   expect_equal(


### PR DESCRIPTION
Note the updated signatures for `mlflow_rfunc_predict()` and `mlflow_rfunc_serve()`