### PR TITLE
Fix tracking into remote server from recent connection changes

### DIFF
--- a/R/mlflow/R/artifact.R
+++ b/R/mlflow/R/artifact.R
@@ -66,7 +66,7 @@ mlflow_artifact_type <- function(artifact_uri) {
 #' by Amazon IAM.
 #'
 #' @export
-mlflow_log_artifact <- function(path, artifact_path, run_uuid = NULL) {
+mlflow_log_artifact <- function(path, artifact_path = NULL, run_uuid = NULL) {
   run_uuid <- mlflow_ensure_run_id(run_uuid)
   artifact_uri <- mlflow_get_run(run_uuid)$info$artifact_uri
   artifact_type <- mlflow_artifact_type(artifact_uri)
@@ -74,7 +74,7 @@ mlflow_log_artifact <- function(path, artifact_path, run_uuid = NULL) {
   artifact_uri <- ifelse(
     is.null(artifact_path),
     artifact_uri,
-    fs::path(artifact_uri, artifact_path)
+    file.path(artifact_uri, artifact_path)
   )
 
   artifact_uri <- structure(

--- a/R/mlflow/R/connection.R
+++ b/R/mlflow/R/connection.R
@@ -20,7 +20,7 @@ mlflow_active_connection <- function() {
 mlflow_set_active_connection <- function(mc) {
   if (!identical(mc, .globals$active_connection)) {
     .globals$active_connection <- mc
-    mlflow_set_tracking_uri(mc$tracking_uri)
+    .globals$tracking_uri <- mc$tracking_uri
     mlflow_set_active_experiment(NULL)
   }
   invisible(mc)
@@ -84,7 +84,9 @@ mlflow_cli_param <- function(args, param, value) {
 mlflow_server <- function(file_store = "mlruns", default_artifact_root = NULL,
                           host = "127.0.0.1", port = 5000, workers = 4, static_prefix = NULL) {
 
-  file_store <- fs::path_abs(file_store)
+  if (is.null(default_artifact_root) || dir.exists(default_artifact_root)) {
+    file_store <- fs::path_abs(file_store)
+  }
 
   args <- mlflow_cli_param(list(), "--port", port) %>%
     mlflow_cli_param("--file-store", file_store) %>%

--- a/R/mlflow/R/remote.R
+++ b/R/mlflow/R/remote.R
@@ -10,6 +10,7 @@ mlflow_set_tracking_uri <- function(uri) {
   .globals$tracking_uri <- uri
   .globals$active_connection <- NULL
   .globals$active_experiment <- NULL
+  .globals$active_run <- NULL
 
   invisible(uri)
 }

--- a/R/mlflow/R/remote.R
+++ b/R/mlflow/R/remote.R
@@ -7,10 +7,10 @@
 #'
 #' @export
 mlflow_set_tracking_uri <- function(uri) {
-  if (!identical(.globals, uri)) {
-    .globals$tracking_uri <- uri
-    mlflow_set_active_experiment(NULL)
-  }
+  .globals$tracking_uri <- uri
+  .globals$active_connection <- NULL
+  .globals$active_experiment <- NULL
+
   invisible(uri)
 }
 

--- a/R/mlflow/R/tracking.R
+++ b/R/mlflow/R/tracking.R
@@ -84,7 +84,7 @@ mlflow_start_run <- function(run_uuid = NULL, experiment_id = NULL, source_name 
     mlflow_get_run(existing_run_uuid)$info
   } else {
     experiment_id <- as.integer(
-      experiment_id %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = "0")
+      experiment_id %||% mlflow_active_experiment() %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = "0")
     )
 
     mlflow_create_run(


### PR DESCRIPTION
Fix to remote tracking, as in:

```
library(mlflow)
mlflow_server(default_artifact_root = "s3://mlflow-test/", port = 5001, file_store = NULL)
```

```
library(mlflow)
mlflow_set_tracking_uri("http://127.0.0.1:5001")
mlflow_create_experiment("remote", "s3://mlflow-test/")
mlflow_log_artifact("document.R")
```

@kevinykuo `fs::path()` does not work well with URL... feel free to open a bug in their repo, but for now, reverted use of `fs::path()`, would be good to check if other paths need to be reverted. Reprex:

```
> fs::path("s3://mlflow-test/", "x")
s3:/mlflow-test/x
```

There are a couple other changes due to connection changes that had to be adjusted.
